### PR TITLE
feat: detect ecmarkup in .html files

### DIFF
--- a/.changeset/slimy-parks-start.md
+++ b/.changeset/slimy-parks-start.md
@@ -1,0 +1,5 @@
+---
+"ecmarkup-language-extension-vscode": minor
+---
+
+Detect emu in html files

--- a/extension-vscode/package.json
+++ b/extension-vscode/package.json
@@ -21,7 +21,9 @@
     "main": "./lib/node.js",
     "type": "module",
     "enableProposedApis": false,
-    "activationEvents": [],
+    "activationEvents": [
+        "onLanguage:html"
+    ],
     "contributes": {
         "configuration": {
             "title": "ecmarkup language service",
@@ -31,6 +33,11 @@
                     "type": "boolean",
                     "default": true,
                     "markdownDescription": "Enable diagnostics\n\n*This feature may have performance issue*"
+                },
+                "ecmarkup.detectInHtml": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Automatically treat `.html` files as ecmarkup when they contain an `<emu-clause` tag.\n\nSome TC39 proposals (e.g. Temporal) write their spec text in `.html` files rather than `.emu`. When enabled, such files are switched to the ecmarkup language mode; other HTML files are left untouched."
                 }
             }
         },

--- a/extension-vscode/src/main.ts
+++ b/extension-vscode/src/main.ts
@@ -1,5 +1,5 @@
-import type { ExtensionContext } from 'vscode'
-import { commands, extensions, workspace } from 'vscode'
+import type { ExtensionContext, TextDocument } from 'vscode'
+import { commands, extensions, languages, workspace } from 'vscode'
 import type { LanguageClient as WebClient, LanguageClientOptions as WebOptions } from 'vscode-languageclient/browser.js'
 import type { LanguageClient as NodeClient, LanguageClientOptions as NodeOptions } from 'vscode-languageclient/node.js'
 import { client as clientAPI } from './io/general.js'
@@ -25,6 +25,14 @@ export async function onActivate(
     client = createClient(clientOptions)
     client.start()
 
+    // VS Code assigns a language by filename/extension, so .html spec files (used by
+    // some TC39 proposals, e.g. Temporal) open as plain HTML and the language server
+    // never sees them. Sniff their content instead: if an HTML document contains an
+    // <emu-clause tag, switch it to the ecmarkup language so the server takes over.
+    // See: https://github.com/Jack-Works/ecmarkup-language-service/issues/12
+    context.subscriptions.push(workspace.onDidOpenTextDocument(detectEcmarkupInHtml))
+    workspace.textDocuments.forEach(detectEcmarkupInHtml)
+
     Object.entries(clientAPI).forEach(([key, f]) => {
         context.subscriptions.push(client!.onRequest(`api/${key}`, (params) => f(...params)))
     })
@@ -34,7 +42,10 @@ export async function onActivate(
     workspace.onDidChangeConfiguration(updateConfiguration)
     updateConfiguration()
     function updateConfiguration() {
-        server.enableDiagnostics(workspace.getConfiguration('ecmarkup').get<boolean>('diagnostic') ?? true)
+        const config = workspace.getConfiguration('ecmarkup')
+        server.enableDiagnostics(config.get<boolean>('diagnostic') ?? true)
+        // If detection was just turned on, pick up already-open HTML spec files.
+        if (config.get<boolean>('detectInHtml') ?? true) workspace.textDocuments.forEach(detectEcmarkupInHtml)
     }
 
     context.subscriptions.push(
@@ -49,6 +60,15 @@ export async function onActivate(
             }
         }),
     )
+}
+
+function detectEcmarkupInHtml(document: TextDocument) {
+    if (document.languageId !== 'html') return
+    if (!(workspace.getConfiguration('ecmarkup').get<boolean>('detectInHtml') ?? true)) return
+    if (!document.getText().includes('<emu-clause')) return
+    // The switch fires onDidOpenTextDocument again, but with languageId 'ecmarkup',
+    // so the languageId guard above prevents re-entry.
+    languages.setTextDocumentLanguage(document, 'ecmarkup')
 }
 
 export async function onDeactivate() {


### PR DESCRIPTION
VS Code assigns languages by filename/extension, so .html spec files (used by some TC39 proposals, e.g. Temporal) opened as plain HTML and the language server never attached. Activate on HTML files and sniff their content: documents containing an `<emu-clause` tag are switched to the ecmarkup language mode, leaving other HTML files untouched. A new `ecmarkup.detectInHtml` setting (default true) opts out.

Closes #12.